### PR TITLE
Update ts-webhook-adapter to correctly handle incoming webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ as an environment variable named `DISCORD_WEBHOOK_URL` for this service.
 ![Discord Webhook integration](images/Discord.png)
 
 If no `DISCORD_WEBHOOK_URL` variable has been set, the Discord delivery will be skipped.
+
+## To Run
+Set up [Tailscale Funnel](https://tailscale.com/kb/1223/funnel). Once enabled then do the following to enable the endpoint:
+1. Install [golang](https://go.dev/doc/install)
+2. Clone this repo locally
+3. cd into the cloned repo and run `go get` then `go build` to compile the ts--adapter
+4. Ensure you've set your envioronment variables applicable above then run the newly compiled program: `./ts-webhook-adapter`
+5. `tailscale funnel 8080` You will get a URL such as `https://<yourhostname>.examplemagic-dns.ts.net/`. Take note of this.
+6. Go back to Tailscale Admin console and create a new Webhook Endpoint. Use `https://<yourhostname>.examplemagic-dns.ts.net/webhook` as the endpoint. Take note to add `/webhook` at the end of the URL.
+7. Test the endpoint by click on the three-dots -> Test endpoint
+You should begin receiving alerts now.

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ import (
 )
 
 type incomingWebhook struct {
-	Timestamp string            `json:"timestamp"`
-	Version   int               `json:"version"`
-	Type      string            `json:"type"`
-	Tailnet   string            `json:"tailnet"`
-	Message   string            `json:"message"`
-	Data      map[string]string `json:"data"`
+	Timestamp string         `json:"timestamp"`
+	Version   int            `json:"version"`
+	Type      string         `json:"type"`
+	Tailnet   string         `json:"tailnet"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data"`
 }
 
 // https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ type incomingWebhook struct {
 	Type      string         `json:"type"`
 	Tailnet   string         `json:"tailnet"`
 	Message   string         `json:"message"`
-	Data      map[string]any `json:"data"`
+	Data      map[string]any `json:"data"` //TODO: Verify if this is the right way to do this.
 }
 
 // https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference


### PR DESCRIPTION
**1)** Suggesting to change `map[string]string` to `map[string]any` in order to allow the request to be correctly processed. This will resolve the following error:

```go
handleWebhook verifyWebhookSignature: json: cannot unmarshal object into Go struct field incomingWebhook.data of type []string
```

**2)** Updated ReadMe to provide a little more detail in configuring this using purely Tailscale's Funnel feature.